### PR TITLE
修复签名方法

### DIFF
--- a/src/main/java/com/qcloud/image/sign/Sign.java
+++ b/src/main/java/com/qcloud/image/sign/Sign.java
@@ -11,35 +11,52 @@ import com.qcloud.image.exception.UnknownException;
  */
 public class Sign {
 
-	/**
-	 * 返回图片识别的签名
-	 * 
-	 * @param cred
-	 *            包含用户秘钥信息
-	 * @param bucketName
-	 *            bucket名
-	 * @param expired
-	 *            超时时间
-	 * @return 返回base64编码的字符串
-	 * @throws AbstractImageException  异常
-	 */
-        public static String appSign(Credentials cred, String bucketName, long expired) throws AbstractImageException {
-            int appId = cred.getAppId();
-            String secretId = cred.getSecretId();
-            String secretKey = cred.getSecretKey();
-            long now = System.currentTimeMillis() / 1000;   
-            int rdm = Math.abs(new Random().nextInt());
-            String plainText = String.format("a=%d&b=%s&k=%s&t=%d&e=%d", appId, bucketName, secretId, now, now+expired);
-            byte[] hmacDigest;
-            try {
-                    hmacDigest = CommonCodecUtils.HmacSha1(plainText, secretKey);
-            } catch (Exception e) {
-                    throw new UnknownException(e.getMessage());
-            }
-            byte[] signContent = new byte[hmacDigest.length + plainText.getBytes().length];
-            System.arraycopy(hmacDigest, 0, signContent, 0, hmacDigest.length);
-            System.arraycopy(plainText.getBytes(), 0, signContent, hmacDigest.length, plainText.getBytes().length);
+    /**
+     * 返回万象图片的多次有效签名
+     *
+     * @param cred       包含用户秘钥信息
+     * @param bucketName bucket名
+     * @param expired    超时时间
+     * @return 返回base64编码的字符串
+     * @throws AbstractImageException 异常
+     */
+    public static String appSign(Credentials cred, String bucketName, long expired) throws AbstractImageException {
+        return appSign(cred, bucketName, "", expired);
+    }
 
-            return CommonCodecUtils.Base64Encode(signContent);
+    /**
+     * 返回万象图片特定资源的多次有效签名
+     *
+     * @param cred       包含用户秘钥信息
+     * @param bucketName bucket名
+     * @param fileid     特定资源（会验证与当前操作的文件路径是否一致）
+     * @param expired    超时时间
+     * @return 返回base64编码的字符串
+     * @throws AbstractImageException 异常
+     */
+    public static String appSign(Credentials cred, String bucketName, String fileid, long expired) throws AbstractImageException {
+        return generateSignature(cred, bucketName, fileid, expired);
+    }
+
+    private static String generateSignature(Credentials cred, String bucketName, String fileid, long expired) throws AbstractImageException {
+        int appId = cred.getAppId();
+        String secretId = cred.getSecretId();
+        String secretKey = cred.getSecretKey();
+        int rdm = Math.abs(new Random().nextInt());
+        long now = System.currentTimeMillis() / 1000;
+
+        String plainText = String.format("a=%d&b=%s&k=%s&t=%d&e=%d&r=%d&f=%s", appId, bucketName, secretId, now, now + expired, rdm, fileid);
+
+        byte[] hmacDigest;
+        try {
+            hmacDigest = CommonCodecUtils.HmacSha1(plainText, secretKey);
+        } catch (Exception e) {
+            throw new UnknownException(e.getMessage());
         }
+        byte[] signContent = new byte[hmacDigest.length + plainText.getBytes().length];
+        System.arraycopy(hmacDigest, 0, signContent, 0, hmacDigest.length);
+        System.arraycopy(plainText.getBytes(), 0, signContent, hmacDigest.length, plainText.getBytes().length);
+
+        return CommonCodecUtils.Base64Encode(signContent);
+    }
 }


### PR DESCRIPTION
在使用时发现签名方法生成出来的签名是无效的，根据[官方文档](https://cloud.tencent.com/document/product/460/6968)实验得出：
1. 字段 r 为必填；
2. 字段 f 虽为可选，但生成签名时也必须包含这个字段